### PR TITLE
Fixed upgrade command

### DIFF
--- a/app/views/docs/record.html.erb
+++ b/app/views/docs/record.html.erb
@@ -19,7 +19,7 @@ Install with:
 
 Later update with:
 
-    $ brew update asciiio
+    $ brew upgrade asciiio
 
 ### OSX (no Homebrew)
 


### PR DESCRIPTION
`brew update foo` => This command updates brew itself, and does not take formula names.

Hence: `brew upgrade asciiio` => Error: asciiio-HEAD already installed
