### PR TITLE
Fix brew install URL

### DIFF
--- a/app/views/docs/record.html.erb
+++ b/app/views/docs/record.html.erb
@@ -15,7 +15,7 @@ command:
 
 Install with:
 
-    $ brew install https://raw.github.com/gist/3875486/asciiio.rb --HEAD
+    $ brew install https://gist.github.com/rogeriopradoj/6672302/raw/4cb8e7054ea01b29f67a7e2e2475a4028c553071/asciinema.rb --HEAD
 
 Later update with:
 


### PR DESCRIPTION
Two points:
- original repo has change its name
- gist doesn't accept just raw.xxxx, we have to use complete location

I think it can be just temporary, while original gist is not updated. I suggest to get this updated version here: https://gist.github.com/rogeriopradoj/6672302
