### PR TITLE
Change commit ref to last one with prepare/render callbacks in libtsm

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -8,7 +8,7 @@ then
   DIR=$(mktemp -d -t tsmXXXXXX)
   cd $DIR
   git clone git://people.freedesktop.org/~dvdhrm/libtsm .
-  git checkout e998bb
+  git checkout bb4e454
   test -f ./configure || NOCONFIGURE=1 ./autogen.sh
   ./configure --prefix=/usr/local
   make


### PR DESCRIPTION
With commit `e998bb`, compilation of `asciinema.org/src/terminal.c` fails with this message

```
root@cloudos-asciinema:~/asciinema.org/src# make
gcc -O3 -o terminal terminal.c -ltsm
terminal.c: In function ‘attr_cp’:
terminal.c:181:5: warning: incompatible implicit declaration of built-in function ‘memcpy’ [enabled by default]
terminal.c: In function ‘main’:
terminal.c:286:17: warning: passing argument 2 of ‘tsm_screen_draw’ from incompatible pointer type [enabled by     default]
In file included from terminal.c:2:0:
/usr/local/include/libtsm.h:259:11: note: expected ‘tsm_screen_draw_cb’ but argument is of type ‘int (*)(struct   tsm_screen *, void *)’
terminal.c:286:17: error: too many arguments to function ‘tsm_screen_draw’
In file included from terminal.c:2:0:
/usr/local/include/libtsm.h:259:11: note: declared here
make: *** [terminal] Error 1
```

In `src/libtsm.h` version from `e998bb`, `tsm_screen_draw` has the following signature:

```
tsm_age_t tsm_screen_draw(struct tsm_screen *con, tsm_screen_draw_cb draw_cb, void *data);
```

when in `bb4e454` it has the expected signature:

```
void tsm_screen_draw(struct tsm_screen *con,
                     tsm_screen_prepare_cb prepare_cb,
                     tsm_screen_draw_cb draw_cb,
                     tsm_screen_render_cb render_cb,
                     void *data);
```

Git log confirms this:

```
~/libtsm.git$ git log --pretty=format:'%h - %s'
[...]
68e64ec - screen: remove empty cell fallback
59a4f7a - screen: remove prepare/render callbacks
bb4e454 - build: remove shl_timer.h
[...]
```
