### PR TITLE
Enable Powerline symbols in embedded player.

### DIFF
--- a/app/assets/stylesheets/embed.sass
+++ b/app/assets/stylesheets/embed.sass
@@ -1,4 +1,5 @@
 //= require source-sans-pro
+//= require powerline-symbols
 //= require player
 
 body.iframe


### PR DESCRIPTION
At the moment, the Powerline symbols support added in 78f31ae3dee15ee9918d6e9b5a62e71ebcbee4c2 does not work in the embedded player because the CSS does not include the font-face rule that defines the font. This pull request sources the necessary CSS snippet to enable use of Powerline symbols in the embedded player.
