### PR TITLE
Fix yaourt install line (cannot be run as root)

### DIFF
--- a/app/views/docs/installation.html.md
+++ b/app/views/docs/installation.html.md
@@ -20,7 +20,7 @@ Nix:
 
 ### Arch Linux
 
-    sudo yaourt -S asciinema
+    yaourt -S asciinema
 
 ### Fedora
 


### PR DESCRIPTION
Running yaourt as root eventually errors out with "Running makepkg as
root is not allowed as it can cause permanent, catastrophic damage to
your system."