### PR TITLE
Update Arch Linux installation doc. yaourt → pacman

### DIFF
--- a/app/views/docs/installation.html.md
+++ b/app/views/docs/installation.html.md
@@ -13,7 +13,7 @@ be installed with pip (Python 3 required):
 
 ### Arch Linux
 
-    yaourt -S asciinema
+    pacman -S asciinema
 
 ### Debian
 


### PR DESCRIPTION
Hi

asciicinema is now directly available with pacman, no need for yaourt anymore.

https://www.archlinux.org/packages/community/any/asciinema/