### PR TITLE
Installation.html.md - openSUSE installation

### DIFF
--- a/app/views/docs/installation.html.md
+++ b/app/views/docs/installation.html.md
@@ -51,6 +51,10 @@ Packages:
 
     pkg_add asciinema
 
+### OpenSUSE
+
+    sudo zypper install asciinema
+
 ### OS X
 
 Homebrew:


### PR DESCRIPTION
The asciinema package is also available in openSUSE, this pull requests adds the installation step to the documentation.

The package is located at this path: http://download.opensuse.org/distribution/leap/42.2/repo/oss/suse/noarch/asciinema-1.3.0-1.2.noarch.rpm

The recorded asciinema installation in asciinema is here:

[![asciicast](https://asciinema.org/a/4iorc31cq3w6wc5kad0nfobg1.png)](https://asciinema.org/a/4iorc31cq3w6wc5kad0nfobg1)