### PR TITLE
Reveal.js support

### DIFF
--- a/app/views/api/asciicasts/show.html.slim
+++ b/app/views/api/asciicasts/show.html.slim
@@ -19,6 +19,14 @@ javascript:
       if (e.data == 'asciicast:play' || e.data[0] == 'asciicast:play') {
         player.play();
       }
+
+      // reveal.js support
+
+      if (e.data == 'slide:start') {
+        player.play();
+      } else if (e.data == 'slide:stop') {
+        player.pause();
+      }
     }
 
     window.addEventListener("message", onMessage, false);

--- a/app/views/api/asciicasts/show.html.slim
+++ b/app/views/api/asciicasts/show.html.slim
@@ -14,4 +14,12 @@ javascript:
       var h = Math.max(document.body.scrollHeight, document.body.offsetHeight);
       target.postMessage(['asciicast:size', { width: w, height: h }], '*');
     }
+
+    function onMessage(e) {
+      if (e.data == 'asciicast:play' || e.data[0] == 'asciicast:play') {
+        player.play();
+      }
+    }
+
+    window.addEventListener("message", onMessage, false);
   });


### PR DESCRIPTION
This brings back "lost" support for `'asciicast:play'` window event, and adds support for Reveal.js's `slide:start` and `slide:stop` events which makes the embedded player integrate nicely with Reveal.js slide deck.