### PR TITLE
Fix links in README.md for Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ recordings are __private by default__ though).
 If you're not comfortable with uploading your terminal sessions to
 asciinema.org, or your company's policy prevents you from doing that, you can
 set up your own instance for private use. See
-our [asciinema web app install guide](docs/INSTALL.md).
+our [asciinema web app install guide](https://github.com/asciinema/asciinema.org/blob/master/docs/INSTALL.md).
 
 Once you have your instance running, point asciinema recorder to it by setting
 API URL in `~/.config/asciinema/config` file as follows:
@@ -42,7 +42,7 @@ Check out our [Contributing](http://asciinema.org/contributing) page, which
 describes multiple ways you can help this project.
 
 If you decide to contribute with the code then please
-read [CONTRIBUTING.md](CONTRIBUTING.md), which covers submitting bugs,
+read [CONTRIBUTING.md](https://github.com/asciinema/asciinema.org/blob/master/CONTRIBUTING.md), which covers submitting bugs,
 requesting new features, preparing your code for a pull request, etc.
 
 ## Security
@@ -50,7 +50,7 @@ requesting new features, preparing your code for a pull request, etc.
 We're serious about the security of this web app and the user data it manages.
 If you find anything that looks like a potential vulnerability please
 read on
-[how to report a security issue](CONTRIBUTING.md#reporting-security-issues).
+[how to report a security issue](https://github.com/asciinema/asciinema.org/blob/master/CONTRIBUTING.md#reporting-security-issues).
 
 ## Authors
 


### PR DESCRIPTION
Some links refer to files in the GitHub repo using a relative URL. This does not work from the Docker Hub page. Now fixed by replacing the links to the absolute GitHub page in the master branch.

See #277 