### PR TITLE
Migrate Users to Accounts for db setup task

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,4 +12,4 @@
 
 Application.put_env(:asciinema, :snapshot_updater, Asciinema.Asciicasts.SnapshotUpdater.Sync)
 
-Asciinema.Users.create_asciinema_user!()
+Asciinema.Accounts.create_asciinema_user!()


### PR DESCRIPTION
The change in c25820677e2f1c216da309f919f38fc51780d96e (Renaming Users module to Accounts) broke the setup task when creating the database.